### PR TITLE
Fix for Issue 2: Explicitly convert Exception to string for Ruby 1.9

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -766,13 +766,13 @@ module Sailthru
         }
         
       rescue Exception => e
-        raise SailthruClientException.new("Unable to open stream: #{_uri.to_s}\n" + e);
+        raise SailthruClientException.new("Unable to open stream: #{_uri}\n#{e}");
       end
       
       if response.body
         return response.body
       else
-        raise SailthruClientException.new("No response received from stream: #{_uri.to_s}")
+        raise SailthruClientException.new("No response received from stream: #{_uri}")
       end
     end
     


### PR DESCRIPTION
String interpolation implicitly calls `to_s`, so I moved the `e` argument into the string. I also removed any unnecessary calls to `to_s` while I was at it. The proper exception should now be raised instead of irrelevant exceptions like "can't convert Errno::ECONNREFUSED into String". Works in 1.8.7, 1.9.1 and 1.9.2.
