### PR TITLE
use Net::HTTP::Proxy and allow configuration of the proxy host and proxy port

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -746,7 +746,7 @@ module Sailthru
       end
 
       begin
-        http = Net::HTTP::PROXY(@proxy_host, @proxy_port).new(_uri.host, _uri.port)
+        http = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(_uri.host, _uri.port)
 
         if _uri.scheme == 'https'
             http.use_ssl = true


### PR DESCRIPTION
Adds optional parameters for proxy_host and proxy_port, and uses Net::HTTP::Proxy instead of Net::HTTP so that it works for apps that are behind a proxy server
