### PR TITLE
Allows users to use StringIO to post params

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ end
 #   http://rubygems.org/read/chapter/20
 #
 spec = Gem::Specification.new do |s|
-  require 'lib/sailthru'
+  require File.join(File.dirname(__FILE__), 'lib', 'sailthru')
   # Change these as appropriate
   s.name              = "sailthru-client"
   s.version           = "#{Sailthru::Version}"
@@ -47,6 +47,7 @@ spec = Gem::Specification.new do |s|
 
   s.add_development_dependency("fakeweb")
   s.add_development_dependency("shoulda")
+  s.add_development_dependency("mocha")
 end
 
 # This task actually builds the gem. We also regenerate a static
@@ -91,7 +92,7 @@ end
 #
 desc "Push a new version to Gemcutter"
 task :publish do
-    require 'lib/sailthru'
+    require File.join(File.dirname(__FILE__), 'lib', 'sailthru')
     sh "rake clean"
     sh "rake gem"
     sh "rake gemspec"

--- a/sailthru-client.gemspec
+++ b/sailthru-client.gemspec
@@ -1,40 +1,42 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{sailthru-client}
+  s.name = "sailthru-client"
   s.version = "1.15"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Prajwal Tuladhar"]
-  s.date = %q{2012-02-10}
-  s.email = %q{praj@sailthru.com}
+  s.date = "2012-08-21"
+  s.email = "praj@sailthru.com"
   s.extra_rdoc_files = ["README.md"]
   s.files = ["README.md", "lib/sailthru.rb"]
-  s.homepage = %q{http://docs.sailthru.com}
+  s.homepage = "http://docs.sailthru.com"
   s.rdoc_options = ["--main", "README.md"]
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.6}
-  s.summary = %q{A simple client library to remotely access the Sailthru REST API.}
+  s.rubygems_version = "1.8.11"
+  s.summary = "A simple client library to remotely access the Sailthru REST API."
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<json>, [">= 0"])
       s.add_runtime_dependency(%q<multipart-post>, [">= 0"])
       s.add_development_dependency(%q<fakeweb>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
+      s.add_development_dependency(%q<mocha>, [">= 0"])
     else
       s.add_dependency(%q<json>, [">= 0"])
       s.add_dependency(%q<multipart-post>, [">= 0"])
       s.add_dependency(%q<fakeweb>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
+      s.add_dependency(%q<mocha>, [">= 0"])
     end
   else
     s.add_dependency(%q<json>, [">= 0"])
     s.add_dependency(%q<multipart-post>, [">= 0"])
     s.add_dependency(%q<fakeweb>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
+    s.add_dependency(%q<mocha>, [">= 0"])
   end
 end

--- a/test/fixtures/user_update_post_valid.json
+++ b/test/fixtures/user_update_post_valid.json
@@ -1,0 +1,3 @@
+{"email" : "test@test.com", "vars" : {"name" : "Dan"}}
+{"email" : "test2@test.com", "vars" : {"name" : "Dan 2"}}
+{"email" : "test3@test.com", "vars" : {"name" : "Dan 3"}}

--- a/test/fixtures/user_update_valid.json
+++ b/test/fixtures/user_update_valid.json
@@ -1,0 +1,1 @@
+{"job_id" : "502c618ddd6a49b9200003c4", "name" : "Bulk Update", "update" : [], "status" : "pending"}

--- a/test/sailthru/file_upload_test.rb
+++ b/test/sailthru/file_upload_test.rb
@@ -1,0 +1,89 @@
+$:.unshift File.join(File.dirname(__FILE__),'..')
+require 'test_helper'
+
+class FileUploadTest < Test::Unit::TestCase
+  
+  context "API Call: blast" do
+    
+    setup do  
+      @secret = 'my_secret'
+      @api_key = 'my_api_key'
+      @sailthru_client = Sailthru::SailthruClient.new(
+        @api_key, @secret, 'http://api.sailthru.com'
+      )
+      @api_call_url = sailthru_api_call_url(
+        'http://api.sailthru.com', 'job'
+      )
+    end
+
+
+    should "be able to upload a file of data" do
+
+      Net::HTTP::Post::Multipart.expects(:new)
+        .with(
+          instance_of(String),
+          has_entries({
+            "file" => instance_of(UploadIO)
+          })
+        )
+
+      Net::HTTP.stubs(:Proxy).returns(Net::HTTP)
+      Net::HTTP.any_instance
+        .stubs(
+          :request => stub(
+            "body" => JSON.unparse({"job_id" => "123"})
+          )
+        )
+
+      data = {
+        "job" => "update",
+        "file" => fixture_file_path('user_update_post_valid.json')
+      }
+
+      response = @sailthru_client.api_post(
+        :job, data, 'file'
+      )
+      
+      assert_not_nil response['job_id']
+    end
+
+    should "be able to upload a string of data" do
+
+      Net::HTTP::Post::Multipart.expects(:new)
+        .with(
+          instance_of(String),
+          has_entries({
+            "file" => instance_of(UploadIO)
+          })
+        )
+
+      Net::HTTP.stubs(:Proxy).returns(Net::HTTP)
+      Net::HTTP.any_instance
+        .stubs(
+          :request => stub(
+            "body" => JSON.unparse({"job_id" => "123"})
+          )
+        )
+
+      email = {
+        "email" => "dan.langevin@lifebooker.com",
+        "vars" => {
+          "first_name" => "Dan"
+        }
+      }
+
+      data = {
+        "job" => "update",
+        "file" => StringIO.new(JSON.unparse(email))
+      }
+
+      response = @sailthru_client.api_post(
+        :job, data, 'file'
+      )
+      
+      assert_not_nil response['job_id']
+
+    end
+
+  end
+end

--- a/test/sailthru/stats_test.rb
+++ b/test/sailthru/stats_test.rb
@@ -42,8 +42,8 @@ class StatsTest < Test::Unit::TestCase
     should "not be able to stats list data when list is given and invalid" do
       list = 'not-listed'
       params = {}
-      params[:stat] = 'list'
       params[:list] = list
+      params[:stat] = 'list'
       query_string = create_json_payload(@api_key, @secret, params)
       stub_get(@api_call_url + '?' + query_string, 'stats_lists_invalid.json')
       response = @sailthru_client.stats_list(list)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,10 @@ require 'test/unit'
 require 'shoulda'
 require 'uri'
 require 'json'
+require 'mocha'
+
+require 'ruby-debug'
+Debugger.start
 
 gem 'fakeweb', ">= 1.2.6"
 require 'fakeweb'
@@ -24,8 +28,11 @@ class Test::Unit::TestCase
 
   def fixture_file(filename)
     return '' if filename == ''
-    file_path = File.expand_path(File.dirname(__FILE__) + '/fixtures/' + filename)
-    File.read(file_path)
+    File.read(fixture_file_path(filename))
+  end
+
+  def fixture_file_path(filename)
+    File.expand_path(File.dirname(__FILE__) + '/fixtures/' + filename)
   end
 
   def sailthru_api_base_url(url)


### PR DESCRIPTION
This prevents you from having to write large files to the filesystem

For example:

``` ruby

client = SailthruClient.new(...)

user_data = StringIO.new
User.all.each do |user|
  user_data.puts({'email' => 'dan.langevin@lifebooker.com', 'vars' => {'name' => 'Dan'}}.to_json)
end

client.api_post(:job, {'data' => user_data}, 'data')

```
