### PR TITLE
Sailthru::Client#send -> #send_email

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -120,7 +120,7 @@ module Sailthru
     #     test: send as test email (subject line will be marked, will not count towards stats)
     # returns:
     #   Hash, response data from server
-    def send(template_name, email, vars={}, options = {}, schedule_time = nil)
+    def send_email(template_name, email, vars={}, options = {}, schedule_time = nil)
       post = {}
       post[:template] = template_name
       post[:email] = email

--- a/test/sailthru/send_test.rb
+++ b/test/sailthru/send_test.rb
@@ -35,7 +35,7 @@ class SendTest < Test::Unit::TestCase
       template_name = 'default'
       email = 'example@example.com'
       stub_post(@api_call_url, 'send_get_valid.json')
-      response = @sailthru_client.send template_name, email, {"name" => "Unix",  "myvar" => [1111,2,3], "mycomplexvar" => {"tags" => ["obama", "aaa", "c"]}}
+      response = @sailthru_client.send_email template_name, email, {"name" => "Unix",  "myvar" => [1111,2,3], "mycomplexvar" => {"tags" => ["obama", "aaa", "c"]}}
       assert_equal template_name, response['template']
     end
 
@@ -43,7 +43,7 @@ class SendTest < Test::Unit::TestCase
       template_name = 'invalid-template'
       email = 'example@example.com'
       stub_post(@api_call_url, 'send_post_invalid.json')
-      response = @sailthru_client.send template_name, email, {"name" => "Unix",  "myvar" => [1111,2,3], "mycomplexvar" => {"tags" => ["obama", "aaa", "c"]}}
+      response = @sailthru_client.send_email template_name, email, {"name" => "Unix",  "myvar" => [1111,2,3], "mycomplexvar" => {"tags" => ["obama", "aaa", "c"]}}
       assert_equal 14, response['error']
     end
 


### PR DESCRIPTION
Naming the method send causes problems with Delayed and Resque. Also,
you should probably never name a method "send" (in ruby).
