### PR TITLE
Keep Send Method for backwards compatibility

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -9,7 +9,7 @@ require 'net/http/post/multipart'
 
 module Sailthru
 
-  Version = VERSION = '1.14'
+  Version = VERSION = '1.15'
 
   class SailthruClientException < Exception
   end
@@ -115,6 +115,24 @@ module Sailthru
     #   template_name, String
     #   email, String
     #   replacements, Hash
+    #   options, Hash
+    #     replyto: override Reply-To header
+    #     test: send as test email (subject line will be marked, will not count towards stats)
+    #   schedule_time, Date
+    # returns:
+    #   Hash, response data from server
+    #
+    # Send a transactional email, or schedule one for the near future
+    # http://docs.sailthru.com/api/send
+    def send(template_name, email, vars={}, options = {}, schedule_time = nil)
+      warn "[DEPRECATION] `send` is deprecated. Please use `send_email` instead."
+      send_email(template_name, email, vars={}, options = {}, schedule_time = nil)
+    end
+
+    # params:
+    #   template_name, String
+    #   email, String
+    #   vars, Hash
     #   options, Hash
     #     replyto: override Reply-To header
     #     test: send as test email (subject line will be marked, will not count towards stats)

--- a/test/sailthru/send_test.rb
+++ b/test/sailthru/send_test.rb
@@ -31,6 +31,22 @@ class SendTest < Test::Unit::TestCase
       assert_equal 12, response['error']
     end
 
+    should "be able to post send with valid template name and email using deprecated 'send' method" do
+      template_name = 'default'
+      email = 'example@example.com'
+      stub_post(@api_call_url, 'send_get_valid.json')
+      response = @sailthru_client.send template_name, email, {"name" => "Unix",  "myvar" => [1111,2,3], "mycomplexvar" => {"tags" => ["obama", "aaa", "c"]}}
+      assert_equal template_name, response['template']
+    end
+
+    should "not be able to post send with invalid template name and/or email using deprecated 'send' method" do
+      template_name = 'invalid-template'
+      email = 'example@example.com'
+      stub_post(@api_call_url, 'send_post_invalid.json')
+      response = @sailthru_client.send template_name, email, {"name" => "Unix",  "myvar" => [1111,2,3], "mycomplexvar" => {"tags" => ["obama", "aaa", "c"]}}
+      assert_equal 14, response['error']
+    end
+
     should "be able to post send with valid template name and email" do
       template_name = 'default'
       email = 'example@example.com'


### PR DESCRIPTION
Given that the send method is an important API call, you'll still want to keep it for backwards compatibility and gradually deprecate it. I also updated the version number to reflect the change and match what is in Rubygems.
