### PR TITLE
Bug 5627

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -321,7 +321,22 @@ module Sailthru
       data[:templates] = templates unless templates.empty?
       self.api_post(:email, data)
     end
-
+    
+    # params:
+    #   new_email, String
+    #   old_email, String
+    #   options, Hash mapping optional parameters
+    # returns:
+    #   Hash of response data.
+    #
+    # change a user's email address.
+    def change_email(new_email, old_email, options = {})
+      data = options
+      data[:email] = new_email
+      data[:change_email] = old_email
+      self.api_post(:email, data)
+    end
+    
     # params:
     #   template_name, String
     # returns:


### PR DESCRIPTION
I have commits for the following in https://github.com/sailthru/sailthru-ruby-client/pull/4:

https://github.com/sailthru/sailthru-ruby-client/commit/8a7af9b1cd352fbee699b001c05a7f24eade381e
https://github.com/sailthru/sailthru-ruby-client/commit/1e18f74f072c6e4b54420566cf95effa6673b28c
https://github.com/sailthru/sailthru-ruby-client/commit/a755fa8c588fbf0e6507d713cd8cee9dc72cd7da

I have chosen not to create a new optout method https://github.com/sailthru/sailthru-ruby-client/commit/1c1ab2f08f0bf6df8c5c38f5a5f6e9b38a03e7ee (as it should be built into set_email), nor create a variety of job wrappers https://github.com/sailthru/sailthru-ruby-client/commit/20731796003c729cc7e9dc93e3012994059f6cbc as they are essentially a wrapper for a process_job method
