### PR TITLE
Added method to verify optout requests

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -401,7 +401,7 @@ module Sailthru
     #   params, Hash
     #   request, String
     # returns:
-    #   TrueClass or FalseClass, Returns true if the incoming request is an authenticated verify post.
+    #   TrueClass or FalseClass, Returns true if the incoming request is an authenticated optout post.
     def receive_optout_post(params, request)
       if request.post?
         [:action, :email, :sig].each { |key| return false unless params.has_key?(key) }


### PR DESCRIPTION
It seemed this method from the API was missing.

See https://github.com/sailthru/sailthru-php5-client/blob/master/sailthru/Sailthru_Client.php#L798-821 for reference
