### PR TITLE
Add support for false value for purchase method incomplete param

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -431,7 +431,7 @@ module Sailthru
       data[:email] = email
       data[:items] = items
 
-      if incomplete != nil
+      if incomplete
         data[:incomplete] = incomplete.to_i
       end
 


### PR DESCRIPTION
In ruby, false and nil and non-truthy values. This change changes the condition from an explicit nil check (which does not work for false values) to one that checks truthiness.
