### PR TITLE
Removing assignment of vars in deprecated #send method

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -126,7 +126,7 @@ module Sailthru
     # http://docs.sailthru.com/api/send
     def send(template_name, email, vars={}, options = {}, schedule_time = nil)
       warn "[DEPRECATION] `send` is deprecated. Please use `send_email` instead."
-      send_email(template_name, email, vars={}, options = {}, schedule_time = nil)
+      send_email(template_name, email, vars, options, schedule_time)
     end
 
     # params:


### PR DESCRIPTION
We discovered that when the deprecated #send method was called, it was overriding whatever vars, options and schedule_time had been passed in and setting them to blank values
