### PR TITLE
Timeouts

### DIFF
--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -941,7 +941,7 @@ module Sailthru
             http.request(req)
         }
 
-      rescue Timeout::Error, EOFError, Errno::ECONNREFUSED, Errno::ECONNRESET => e
+      rescue Timeout::Error => e
         raise SailthruUnavailableException.new(["Timed out: #{_uri}", e.inspect, e.backtrace].join("\n"));
       rescue Exception => e
         raise SailthruClientException.new(["Unable to open stream: #{_uri}", e.inspect, e.backtrace].join("\n"));


### PR DESCRIPTION
updated sailthru client to accepts opts hash on construction as well as set default values for timeouts
