### PR TITLE
Fixed failing test and cleaned up syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,14 @@
+source "https://rubygems.org"
+ruby '1.8.7'
+
+gem 'rake', '0.9.6'
+gem 'multipart-post'
+
+group :test do
+  gem 'json'
+  gem 'shoulda'
+  gem 'shoulda-matchers', '<2'
+  gem 'activesupport', '<4'
+  gem 'ruby-debug'
+  gem 'fakeweb'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,46 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (3.2.17)
+      i18n (~> 0.6, >= 0.6.4)
+      multi_json (~> 1.0)
+    bourne (1.5.0)
+      mocha (>= 0.13.2, < 0.15)
+    columnize (0.8.9)
+    fakeweb (1.3.0)
+    i18n (0.6.9)
+    json (1.8.1)
+    linecache (0.46)
+      rbx-require-relative (> 0.0.4)
+    metaclass (0.0.4)
+    mocha (0.14.0)
+      metaclass (~> 0.0.1)
+    multi_json (1.9.3)
+    multipart-post (2.0.0)
+    rake (0.9.6)
+    rbx-require-relative (0.0.9)
+    ruby-debug (0.10.4)
+      columnize (>= 0.1)
+      ruby-debug-base (~> 0.10.4.0)
+    ruby-debug-base (0.10.4)
+      linecache (>= 0.3)
+    shoulda (3.5.0)
+      shoulda-context (~> 1.0, >= 1.0.1)
+      shoulda-matchers (>= 1.4.1, < 3.0)
+    shoulda-context (1.2.1)
+    shoulda-matchers (1.5.6)
+      activesupport (>= 3.0.0)
+      bourne (~> 1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  activesupport (< 4)
+  fakeweb
+  json
+  multipart-post
+  rake (= 0.9.6)
+  ruby-debug
+  shoulda
+  shoulda-matchers (< 2)

--- a/lib/sailthru.rb
+++ b/lib/sailthru.rb
@@ -878,7 +878,7 @@ module Sailthru
 
         if binary_data.is_a?(StringIO)
           data[binary_key] = UploadIO.new(
-            binary_data, "text/plain"
+            binary_data, "text/plain", "local.path"
           )
         else
           data[binary_key] = UploadIO.new(

--- a/test/sailthru/file_upload_test.rb
+++ b/test/sailthru/file_upload_test.rb
@@ -19,8 +19,7 @@ class FileUploadTest < Test::Unit::TestCase
 
     should "be able to upload a file of data" do
 
-      Net::HTTP::Post::Multipart.expects(:new)
-        .with(
+      Net::HTTP::Post::Multipart.expects(:new).with(
           instance_of(String),
           has_entries({
             "file" => instance_of(UploadIO)
@@ -28,8 +27,7 @@ class FileUploadTest < Test::Unit::TestCase
         )
 
       Net::HTTP.stubs(:Proxy).returns(Net::HTTP)
-      Net::HTTP.any_instance
-        .stubs(
+      Net::HTTP.any_instance.stubs(
           :request => stub(
             "body" => JSON.unparse({"job_id" => "123"})
           )
@@ -49,8 +47,7 @@ class FileUploadTest < Test::Unit::TestCase
 
     should "be able to upload a string of data" do
 
-      Net::HTTP::Post::Multipart.expects(:new)
-        .with(
+      Net::HTTP::Post::Multipart.expects(:new).with(
           instance_of(String),
           has_entries({
             "file" => instance_of(UploadIO)
@@ -58,8 +55,7 @@ class FileUploadTest < Test::Unit::TestCase
         )
 
       Net::HTTP.stubs(:Proxy).returns(Net::HTTP)
-      Net::HTTP.any_instance
-        .stubs(
+      Net::HTTP.any_instance.stubs(
           :request => stub(
             "body" => JSON.unparse({"job_id" => "123"})
           )


### PR DESCRIPTION
The client code that sends a string for upload, instead of reading from a file, has been updated to pass a filename to use, following the documentation for the multipart-post gem UploadIO#initialize method: https://github.com/nicksieger/multipart-post/blob/abb54501ecb43e554723c9fa2a814a19b6348bbe/lib/composite_io.rb#L65

Also cleaned up some calls in the file_upload_test.rb file where the dot-operator and method name were separated with a newline from the object having the method invoked upon it, in a few places.

Added Gemfile and Gemfile.lock in order to pin correct gem dependency versions for developer testing.
