### PR TITLE
Fix reference to the version

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -788,7 +788,7 @@ module Sailthru
       end
 
       req = nil
-      headers = {"User-Agent" => "Sailthru API Ruby Client #{VERSION}"}
+      headers = {"User-Agent" => "Sailthru API Ruby Client #{Sailthru::VERSION}"}
 
       _uri  = URI.parse(uri)
 


### PR DESCRIPTION
I was getting an undefined error, this fixes that. 

I thought `::VERSION` should work but I had to use the full path.
