### PR TITLE
Raise SailThru::UnavailableError when unable to parse API response

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -745,7 +745,7 @@ module Sailthru
           unserialized = JSON.parse(_result)
           return unserialized ? unserialized : _result
         rescue JSON::JSONError => e
-          return {'error' => e}
+          raise UnavailableError, "Failed to parse response body:  #{_result}"
         end
       end
       _result


### PR DESCRIPTION
If the client fails to parse the response body, then the API is presumed to be malfunctioning and unavailable.  Throw an `UnavailableError` including the actual response body returned.

Only return a ruby hash when a parsable response is returned from the API, including a valid error code.  e.g. `{ 'error'=> 9 }`

Values for `error` should only ever include valid [SailThru error codes](http://getstarted.sailthru.com/api/api-response-errors) returned in a well-formed response body.
