### PR TITLE
Add `receive_list_post` method

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -306,10 +306,9 @@ module Sailthru
 
         sig = params.delete(:sig)
         params.delete(:controller)
-        return false unless sig == get_signature_hash(params, @secret)
-        return true
+        sig == get_signature_hash(params, @secret)
       else
-        return false
+        false
       end
     end
 
@@ -326,10 +325,9 @@ module Sailthru
 
         sig = params.delete(:sig)
         params.delete(:controller)
-        return false unless sig == get_signature_hash(params, @secret)
-        return true
+        sig == get_signature_hash(params, @secret)
       else
-        return false
+        false
       end
     end
 
@@ -347,10 +345,9 @@ module Sailthru
 
         sig = params.delete(:sig)
         params.delete(:controller)
-        return false unless sig == get_signature_hash(params, @secret)
-        return true
+        sig == get_signature_hash(params, @secret)
       else
-        return false
+        false
       end
     end
 

--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -317,6 +317,27 @@ module Sailthru
     #   params, Hash
     #   request, String
     # returns:
+    #   TrueClass or FalseClass, Returns true if the incoming request is an authenticated list post.
+    def receive_list_post(params, request)
+      if request.post?
+        [:action, :email, :sig].each { |key| return false unless params.has_key?(key) }
+
+        return false unless params[:action] == 'update'
+
+        sig = params.delete(:sig)
+        params.delete(:controller)
+        return false unless sig == get_signature_hash(params, @secret)
+        return true
+      else
+        return false
+      end
+    end
+
+
+    # params:
+    #   params, Hash
+    #   request, String
+    # returns:
     #   TrueClass or FalseClass, Returns true if the incoming request is an authenticated hardbounce post.
     def receive_hardbounce_post(params, request)
       if request.post?

--- a/test/sailthru/receive_post_callback_test.rb
+++ b/test/sailthru/receive_post_callback_test.rb
@@ -39,6 +39,19 @@ class ReceivePostCallbackTest < Minitest::Test
       assert @sailthru_client.receive_optout_post(params, mock(:post? => true))
     end
 
+    it "can validate a list callback" do
+      params = {
+        :email => 'ian@sailthru.com',
+        :page => 'optout',
+        :optout_email => 'none',
+        :lists => {'All Users' => '0'},
+        :action => 'update',
+        :api_key => @api_key
+      }
+      params[:sig] = get_signature_hash(params, @secret)
+      assert @sailthru_client.receive_list_post(params, mock(:post? => true))
+    end
+
     it "can validate a hardbounce callback" do
       params = {
         :email => 'ian@sailthru.com',


### PR DESCRIPTION
This PR adds a `receive_list_post` method which verifies a [list postback](http://getstarted.sailthru.com/api/api-postbacks). (Code is from Robert Hegedus)