### PR TITLE
Makes bundler load the gem correctly.

### DIFF
--- a/lib/sailthru-client.rb
+++ b/lib/sailthru-client.rb
@@ -1,0 +1,1 @@
+require 'sailthru'


### PR DESCRIPTION
As mentioned on #60.

Bundler convention requires a specific naming for gems.
this commits avoids having to add a require to the gemfile.