### PR TITLE
fixes purchase method documentation

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -366,7 +366,7 @@ module Sailthru
 
     # params:
     #   email, String
-    #   items, String
+    #   items, Array of Hashes
     #   incomplete, Integer
     #   message_id, String
     #   options, Hash


### PR DESCRIPTION
Passing a `String` here doesn't work, I am guessing maybe the original thought was to pass a JSON string or just some bad copy/paste happened, but `items` should be an `Array` of Hashes like:

`items = [{price: 1099, qty: 22, title: 'High-Impact Water Bottle', url: 'http://example.com/234/high-impact-water-bottle', id: '234'}]`