### PR TITLE
Simplify push content and support updating by custom key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.2.0
+  - added save_content supporting all fields from updated api
+  - push_content is now deprecated in favour of save_content
+
 ## 4.1.0
   - added get_last_rate_limit_info method call
 

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@ An [API client library](https://getstarted.sailthru.com/developers/api-client/li
 For installation instructions, documentation, and examples please visit:
 [https://getstarted.sailthru.com/developers/api-client/ruby/](https://getstarted.sailthru.com/developers/api-client/ruby/)
 
+## Running tests
+
+1. `bundle install`
+2. `bundle exec rake test`

--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -235,10 +235,10 @@ module Sailthru
       data[:change_email] = old_email
       api_post(:email, data)
     end
-  
+
     # returns:
     #   Hash of response data.
-    # 
+    #
     # Get all templates
     def get_templates(templates = {})
       api_get(:template, templates)
@@ -468,6 +468,7 @@ module Sailthru
       api_get(:stats, data)
     end
 
+    # <b>DEPRECATED:</b> Please use save_content
     # params
     #   title, String
     #   url, String
@@ -494,6 +495,21 @@ module Sailthru
       if vars.length > 0
         data[:vars] = vars
       end
+      api_post(:content, data)
+    end
+
+    # params
+    #   id, String – An identifier for the item (by default, the item’s URL).
+    #   options, Hash - Containing any of the parameters described on
+    #                     https://getstarted.sailthru.com/developers/api/content/#POST_Mode
+    #
+    # Push a new piece of content to Sailthru, triggering any applicable alerts.
+    # http://docs.sailthru.com/api/content
+    def save_content(id, options)
+      data = options
+      data[:id] = id
+      data[:tags] = data[:tags].join(',') if data[:tags].respond_to?(:join)
+
       api_post(:content, data)
     end
 

--- a/lib/sailthru/version.rb
+++ b/lib/sailthru/version.rb
@@ -1,3 +1,3 @@
 module Sailthru
-  VERSION = '4.1.0'
+  VERSION = '4.2.0'
 end

--- a/test/sailthru/content_test.rb
+++ b/test/sailthru/content_test.rb
@@ -10,6 +10,97 @@ class ContentTest < Minitest::Test
       @api_call_url = sailthru_api_call_url(api_url, 'content')
     end
 
+    describe '#save_content' do
+      describe 'creating a content' do
+        before do
+          id = 'http://example.com/hello-world'
+          options = {
+            keys: {
+              sku: "123abc"
+            },
+            title: "Product Name Here",
+            description: "Product info text goes here.",
+            price: 2099,
+            inventory: 42,
+            date: "2016-06-20 14:30:00 -0400",
+            tags: "blue, jeans, size-m",
+            vars: {
+              var1: "var 1 value"
+            },
+            images: {
+              full: {
+                url: "http://example.com/images/product.jpg"
+              }
+            },
+            site_name: "Store"
+          }
+
+          stub_post(@api_call_url, 'content_valid.json')
+
+          @response = @sailthru_client.save_content(id, options)
+          @last_request_params = CGI::parse(FakeWeb.last_request.body)
+          @expected_form_params = options.merge({id: id})
+        end
+
+        it 'POST to the correct url' do
+          refute_nil @response['content']
+        end
+
+        it 'POST with the correct parameters' do
+          form_data = JSON.parse(@last_request_params["json"][0], symbolize_names: true)
+          assert_equal(form_data, @expected_form_params)
+        end
+      end
+
+      describe 'updating content by url and sending tags as array' do
+        before do
+          id = 'http://example.com/hello-world'
+          options = {
+            tags: ['tag1', 'tag2'],
+          }
+
+          stub_post(@api_call_url, 'content_valid.json')
+
+          @response = @sailthru_client.save_content(id, options)
+          @last_request_params = CGI::parse(FakeWeb.last_request.body)
+          @expected_form_params = options.merge({id: id})
+        end
+
+        it 'POST to the correct url' do
+          refute_nil @response['content']
+        end
+
+        it 'POST form_data tags as string separated by ","' do
+          form_data = JSON.parse(@last_request_params["json"][0], symbolize_names: true)
+          assert_equal(form_data[:tags], 'tag1,tag2')
+        end
+      end
+
+      describe 'updating content searching by sku key instead of url' do
+        before do
+          id = '123abc'
+          options = {
+            key: 'sku',
+            title: "New Product Name Here",
+          }
+
+          stub_post(@api_call_url, 'content_valid.json')
+
+          @response = @sailthru_client.save_content(id, options)
+          @last_request_params = CGI::parse(FakeWeb.last_request.body)
+          @expected_form_params = options.merge({id: id})
+        end
+
+        it 'POST to the correct url' do
+          refute_nil @response['content']
+        end
+
+        it 'POST with the correct parameters' do
+          form_data = JSON.parse(@last_request_params["json"][0], symbolize_names: true)
+          assert_equal(form_data, @expected_form_params)
+        end
+      end
+    end
 
     describe '#push_content: DEPRECATED IN FAVOUR OF save_content' do
       describe 'create content item' do

--- a/test/sailthru/content_test.rb
+++ b/test/sailthru/content_test.rb
@@ -10,27 +10,76 @@ class ContentTest < Minitest::Test
       @api_call_url = sailthru_api_call_url(api_url, 'content')
     end
 
-    it "can push content with title, url, *array* tags and vars" do
-      title = 'unix is awesome'
-      url = 'http://example.com/hello-world'
-      date = nil
-      tags = ['unix', 'linux']
-      vars = {:price => 55, :description => 'Hello World'}
-      stub_post(@api_call_url, 'content_valid.json')
-      response = @sailthru_client.push_content(title, url, date = nil, tags = tags, vars = vars)
-      refute_nil response['content']
-    end
 
-    it "can push content with title, url, *string* tags and vars" do
-      title = 'unix is awesome'
-      url = 'http://example.com/hello-world'
-      date = nil
-      tags = 'unix, linux'
-      vars = {:price => 55, :description => 'Hello World'}
-      stub_post(@api_call_url, 'content_valid.json')
-      response = @sailthru_client.push_content(title, url, date = nil, tags = tags, vars = vars)
-      refute_nil response['content']
-    end
+    describe '#push_content: DEPRECATED IN FAVOUR OF save_content' do
+      describe 'create content item' do
+        before do
+          title = 'Product Name here'
+          url = "http://example.com/product"
+          tags = "blue, jeans, size-m"
+          date = nil
+          vars = {
+            var1: 'var 1 value'
+          }
+          options = {
+            keys: {
+              sku: "123abc"
+            },
+            description: "Product info text goes here.",
+            price: 2099,
+            inventory: 42,
+            images: {
+              full: {
+                url: "http://example.com/images/product.jpg"
+              }
+            },
+            site_name: "Store"
+          }
 
+          stub_post(@api_call_url, 'content_valid.json')
+          @response = @sailthru_client.push_content(title, url, date, tags, vars, options)
+
+          @last_request_params = CGI::parse(FakeWeb.last_request.body)
+
+          @expected_form_params = options.merge({
+            title: title,
+            url: url,
+            vars: vars,
+            tags: tags,
+          })
+        end
+
+        it 'POST to the correct url' do
+          refute_nil @response['content']
+        end
+
+        it 'POST with the correct parameters' do
+          form_data = JSON.parse(@last_request_params["json"][0], symbolize_names: true)
+          assert_equal(form_data, @expected_form_params)
+        end
+      end
+
+      describe 'create content item with tags as array' do
+        before do
+          title = 'Product Name here'
+          url = "http://example.com/product"
+          tags = ['blue', 'jeans', 'size-m']
+
+          stub_post(@api_call_url, 'content_valid.json')
+          @response = @sailthru_client.push_content(title, url, nil, tags)
+
+          @last_request_params = CGI::parse(FakeWeb.last_request.body)
+        end
+
+        it 'POST to the correct url' do
+          refute_nil @response['content']
+        end
+
+        it 'POST form_data tags as string separated by ","' do
+          form_data = JSON.parse(@last_request_params["json"][0], symbolize_names: true)
+          assert_equal(form_data[:tags], 'blue,jeans,size-m')
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
# Why
I was trying to use the current ruby client to generate some content and it was confusing to use because the examples are showing `price` as part of `vars`, to actually set it we have to set the variable `options`.

I believe the current method signature is quite confusing and my proposal is to change it to be as simple as the `save_user` method. https://github.com/sailthru/sailthru-ruby-client/blob/master/lib/sailthru/client.rb#L659

# Changes
- new method called `save_content` similiar to `save_user`
- deprecating `push_content` and keeping backward compatibility
- improved tests to ensure that we are checking sent data

The advantages are that we don't need to update the ruby library keeping the parameters in sync and it's easier to update a content type by using a key other than `url`.

This is related to https://github.com/sailthru/sailthru-ruby-client/pull/73, but simpler.

# Doc Updates
If accepted, I believe we should update https://getstarted.sailthru.com/developers/api-client/ruby/#push_contenttitle_url_date_nil_tags_nil_vars__options to:

## save_content(id, options = {})

* Underlying Endpoint: [content POST](https://getstarted.sailthru.com/developers/api/content/#POST_Mode)
* Save data in options to the content with id or create it if nonexistent. Returns a JSON document indicating whether save was successful.

    Parameters
        id (required) – the string id of the content (Defaults to `url`)
            Can specify `key` in options for all other key values
        options (optional) – optional parameters e.g. `{title: 'Item title'}`

### Example: Add a piece of content
```
          id = 'http://example.com/hello-world'
          options = {
            keys: { sku: '123' },
            title: 'My Title',
            tags: ['tag1', 'tag2'],
          }

          response = sailthru_client.save_content(id, options)
```

### Example: Update content using a custom key
```
          id = '123'
          options = {
            key: 'sku',
            title: 'My Title Changed',
            price: 2550
          }

          response = sailthru_client.save_content(id, options)
```