### PR TITLE
send_id is not always included in opt out 

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -284,7 +284,7 @@ module Sailthru
     #   boolean, Returns true if the incoming request is an authenticated verify post.
     def receive_verify_post(params, request)
       if request.post?
-        [:action, :email, :send_id, :sig].each { |key| return false unless params.has_key?(key) }
+        [:action, :email, :sig].each { |key| return false unless params.has_key?(key) }
 
         return false unless params[:action] == :verify
 
@@ -292,14 +292,16 @@ module Sailthru
         params.delete(:controller)
         return false unless sig == get_signature_hash(params, @secret)
 
-        _send = get_send(params[:send_id])
-        return false unless _send.has_key?('email')
+        if params[:send_id]
+          _send = get_send(params[:send_id])
+          return false unless _send.has_key?('email')
 
-        return false unless _send['email'] == params[:email]
+          return false unless _send['email'] == params[:email]
+        end
 
-        return true
+        true
       else
-        return false
+        false
       end
     end
 


### PR DESCRIPTION
I reached out to support on this as well.

I'm having some issues with the output postback stuff which we are trying to use to capture optouts from sailthru and sync them back to our database.

According to the [Sailthru docs](https://getstarted.sailthru.com/developers/api-basics/postbacks/)
> If the message is used as double opt-in and the verification is successful, the send_id and email address will be posted to this url.

We aren't using double opt in and we're not getting `send_id` on the postback. So... if its not there don't validate it.