### PR TITLE
Updates TLS version to 1.2

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -880,7 +880,7 @@ module Sailthru
         http = Net::HTTP::Proxy(@proxy_host, @proxy_port).new(_uri.host, _uri.port)
 
         if _uri.scheme == 'https'
-          http.ssl_version = :TLSv1
+          http.ssl_version = :TLSv1_2
           http.use_ssl = true
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE if @verify_ssl != true  # some openSSL client doesn't work without doing this
           http.ssl_timeout = @opts[:http_ssl_timeout] || 5


### PR DESCRIPTION
I received a email:

> On Sept. 1, 2020, we will disable TLS1.0 and TLS1.1 access to the Sailthru API. To prevent a service interruption, your integration must begin using TLS1.2 before that time. After Sept. 1 at 12:01 a.m. EST, we will not accept requests to our API sent over TLS1.0 or TLS1.1. The connection will be rejected.
> 
> We created a temporary API URL that only responds to requests using TLS1.2. This URL matches the behavior of Sailthru’s API beginning Sept. 1. This testing URL is  https://apitmp.sailthru.com and it allows the full set of API endpoints for your account.