### PR TITLE
Add preview API support

### DIFF
--- a/lib/sailthru/client.rb
+++ b/lib/sailthru/client.rb
@@ -748,6 +748,19 @@ module Sailthru
       api_post(:event, data)
     end
 
+    # params 
+    #   email, String
+    #   type, String,
+    #   id, String
+    # Get a preview of a template, any custom HTML/Zephyr, campaign, or recurring campaign.
+    # https://getstarted.sailthru.com/developers/api/preview/
+    def preview(email, type, id)
+      data = {}
+      data[type] = id
+      data['email'] = email
+      self.api_get('preview', data)
+    end
+
     # Perform API GET request
     def api_get(action, data)
       api_request(action, data, 'GET')

--- a/test/sailthru/preview_test.rb
+++ b/test/sailthru/preview_test.rb
@@ -1,0 +1,6 @@
+require 'test_helper'
+
+class PreviewTest < Minitest::Test
+  describe "API Call: preview" do
+  end
+end


### PR DESCRIPTION
This PR adds Sailthru preview API support to the library. See https://getstarted.sailthru.com/developers/api/preview/ 

Examples:
```ruby
preview('test@test.com', 'blast_id', '8290891')
preview('test@test.com', 'template', 'Welcome')
preview('test@test.com', 'blast_repeat_id', '58115c48e9328b03068b45a3')
preview('test@test.com', 'content_html', '<p>Hello world</p>')
```

I haven't been able to get the test suite to run due to https://github.com/sailthru/sailthru-ruby-client/issues/85 so I haven't added any tests. If anyone has recommendations, that would be great.