### PR TITLE
Add a few tests for the `process_job` method

### DIFF
--- a/test/fixtures/job_content_update_file.json
+++ b/test/fixtures/job_content_update_file.json
@@ -1,0 +1,2 @@
+{"url":"https://example.com/123/water_bottle-outdoor","inventory":47}
+{"url":"https://example.com/123/water_bottle-sport","title":"Sports Water Bottle"}

--- a/test/fixtures/job_content_update_post_valid.json
+++ b/test/fixtures/job_content_update_post_valid.json
@@ -1,0 +1,1 @@
+{"job_id":"635a04fa1628f53d490220d7","name":"Content Update","status":"pending"}

--- a/test/sailthru/job_test.rb
+++ b/test/sailthru/job_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class JobTest < Minitest::Test
+  describe "API Call: job" do
+    before do
+      api_url = 'http://api.sailthru.com'
+      @secret = 'my_secret'
+      @api_key = 'my_api_key'
+      @sailthru_client = Sailthru::Client.new(@api_key, @secret, api_url)
+      @api_call_url = sailthru_api_call_url(api_url, 'job')
+    end
+
+    it "can create or update content from a JSON file" do
+      file_path = fixture_file_path('job_content_update_file.json')
+      stub_post(@api_call_url, 'job_content_update_post_valid.json')
+      response = @sailthru_client.process_job('content_update', { 'file' => file_path }, nil, nil, 'file')
+      assert_equal 'Content Update', response['name']
+      assert_equal 'pending', response['status']
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a few tests for the `process_job` method being called with the [`content_update`](https://getstarted.sailthru.com/developers/api/job-content/#content-update) job parameter. The tests themselves can be used as an example of how the `process_job` method should be called to create/update content from a JSON file.

The new version of the gem is not required to be published now, because the PR doesn't add any bug fixes or new features.